### PR TITLE
Add market cap fetch for new ticker list

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -41,3 +41,5 @@ pip install yfinance pandas
 ---
 ## Updating Ticker List
 The application now downloads the latest list of U.S. and Canadian tickers at startup using `fetch_latest_tickers()` in `ticker_fetcher.py`. If the download fails, it falls back to the cached `tickers.csv` file.
+
+`fetch_latest_tickers()` expects the downloaded CSV to contain the columns `ticker`, `name`, `is_etf` and `exchange`. The script then queries Yahoo Finance for each ticker to obtain the current market cap, which is added to the resulting DataFrame.

--- a/ticker_fetcher.py
+++ b/ticker_fetcher.py
@@ -2,8 +2,11 @@ import io
 import pandas as pd
 import requests
 
+# These endpoints now return only the following columns:
+# ticker, name, is_etf, exchange
 US_URL = "https://dumbstockapi.com/stock?exchanges=NYSE,NASDAQ,AMEX&format=csv"
 CA_URL = "https://dumbstockapi.com/stock?exchanges=TSX,TSXV&format=csv"
+YF_QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote?symbols={}"
 
 
 def _download_csv(url):
@@ -11,6 +14,20 @@ def _download_csv(url):
     resp = requests.get(url, timeout=10)
     resp.raise_for_status()
     return pd.read_csv(io.StringIO(resp.text))
+
+
+def _fetch_market_cap(symbol):
+    """Return the market cap for a ticker using Yahoo Finance."""
+    try:
+        resp = requests.get(YF_QUOTE_URL.format(symbol), timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        results = data.get("quoteResponse", {}).get("result", [])
+        if results:
+            return results[0].get("marketCap")
+    except Exception as exc:
+        print(f"Failed to fetch market cap for {symbol}: {exc}")
+    return None
 
 
 def fetch_latest_tickers():
@@ -29,26 +46,28 @@ def fetch_latest_tickers():
             print(f"Failed to download {market} tickers: {exc}")
             continue
 
-        # Normalize column names that may differ between sources
+        # Column names are expected to be ticker, name, is_etf and exchange
         mapping = {col.lower().strip(): col for col in df.columns}
-        symbol_col = mapping.get("symbol")
+        symbol_col = mapping.get("ticker")
         name_col = mapping.get("name")
-        cap_col = mapping.get("marketcap") or mapping.get("market cap")
-        exchange_col = mapping.get("exchange") or mapping.get("market")
+        etf_col = mapping.get("is_etf")
+        exchange_col = mapping.get("exchange")
 
-        if not symbol_col or not name_col or not cap_col:
+        if not symbol_col or not name_col or not exchange_col:
             print(f"Missing columns in {market} data; skipping")
             continue
 
-        sub = df[[symbol_col, name_col, cap_col]].copy()
-        sub.columns = ["Symbol", "Name", "Market Cap"]
-        sub["Market"] = df[exchange_col] if exchange_col else market
+        sub = df[[symbol_col, name_col, etf_col, exchange_col]].copy()
+        sub.columns = ["Symbol", "Name", "is_etf", "Market"]
         frames.append(sub)
 
     if not frames:
         raise RuntimeError("No ticker data could be fetched")
 
     result = pd.concat(frames, ignore_index=True)
+
+    # Fetch market caps individually using Yahoo Finance
+    result["Market Cap"] = result["Symbol"].apply(_fetch_market_cap)
 
     # Ensure numeric market caps for sorting
     result["Market Cap"] = pd.to_numeric(result["Market Cap"], errors="coerce")


### PR DESCRIPTION
## Summary
- update README on ticker list expectations
- enhance `fetch_latest_tickers` to work with new ticker CSV that returns only ticker, name, is_etf and exchange
- fetch market caps from Yahoo Finance

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a5dab4bf4832fb43b726736d6d313