### PR TITLE
Switch ticker source to MarketCap

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -40,6 +40,12 @@ Open the terminal
 pip install yfinance pandas
 ---
 ## Updating Ticker List
-The application now downloads the latest list of U.S. and Canadian tickers at startup using `fetch_latest_tickers()` in `ticker_fetcher.py`. If the download fails, it falls back to the cached `tickers.csv` file.
+The application now downloads the latest list of U.S. and Canadian tickers at
+startup using `fetch_latest_tickers()` in `ticker_fetcher.py`. The function
+retrieves ticker data from the MarketCap API. If the download fails, it falls
+back to the cached `tickers.csv` file.
 
-`fetch_latest_tickers()` expects the downloaded CSV to contain the columns `ticker`, `name`, `is_etf` and `exchange`. The script then queries Yahoo Finance for each ticker to obtain the current market cap, which is added to the resulting DataFrame.
+`fetch_latest_tickers()` expects the JSON response to include the fields
+`symbol`, `name`, `is_etf` and `exchange`. The script then queries Yahoo
+Finance for each ticker to obtain the current market cap, which is added to the
+resulting DataFrame.


### PR DESCRIPTION
## Summary
- replace DumbStockApi with MarketCap API
- update README to explain the new API

## Testing
- `python -m py_compile ticker_fetcher.py`

------
https://chatgpt.com/codex/tasks/task_e_687a6e52725c832f91bf13f86593d539