### PR TITLE
Add Nasdaq screener parser

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -49,3 +49,18 @@ back to the cached `tickers.csv` file.
 `symbol`, `name`, `is_etf` and `exchange`. The script then queries Yahoo
 Finance for each ticker to obtain the current market cap, which is added to the
 resulting DataFrame.
+
+## Parsing Nasdaq Screener JSON
+
+The repository also includes `parse_nasdaq_rows.py` for working with the raw
+JSON from the Nasdaq screener. The utility extracts the `symbol`, `name`,
+`marketCap` and `country` fields from the `rows` array.
+
+Run it by passing the downloaded JSON file:
+
+```bash
+python parse_nasdaq_rows.py nasdaq.json > clean_rows.json
+```
+
+The output is a simplified list of dictionaries containing only the selected
+fields.

--- a/parse_nasdaq_rows.py
+++ b/parse_nasdaq_rows.py
@@ -1,0 +1,40 @@
+import json
+import sys
+
+
+def extract_fields(rows):
+    """Return list of dicts with selected fields from Nasdaq screener rows."""
+    selected = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        symbol = row.get("symbol")
+        name = row.get("name")
+        market_cap = row.get("marketCap")
+        country = row.get("country")
+        if symbol and name:
+            selected.append({
+                "symbol": symbol,
+                "name": name,
+                "marketCap": market_cap,
+                "country": country,
+            })
+    return selected
+
+
+def main(path):
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    rows = data.get("rows") if isinstance(data, dict) else data
+    if rows is None:
+        print("No rows found in JSON", file=sys.stderr)
+        sys.exit(1)
+    result = extract_fields(rows)
+    json.dump(result, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <nasdaq_json_file>")
+        sys.exit(1)
+    main(sys.argv[1])


### PR DESCRIPTION
## Summary
- add `parse_nasdaq_rows.py` for extracting selected fields from Nasdaq screener JSON
- document the new script in the README

## Testing
- `python -m py_compile StockEval.py app.py ticker_fetcher.py parse_nasdaq_rows.py`


------
https://chatgpt.com/codex/tasks/task_e_687a71f1648c832f90e8013a67b3382c