### PR TITLE
Handle Canadian tickers

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -12,7 +12,8 @@ async function searchTicker() {
     data.forEach(stock => {
         const item = document.createElement("div");
         item.className = "suggestion-item";
-        item.innerText = `${stock.Name} (${stock.Symbol})`;
+        const country = stock.CountryShort ? ` - ${stock.CountryShort}` : '';
+        item.innerText = `${stock.Name} (${stock.Symbol})${country}`;
         item.onclick = () => {
             document.getElementById("search").value = '';
             showResults();


### PR DESCRIPTION
## Summary
- show country shortform in search suggestions
- automatically append `.TO` when evaluating Canadian tickers

## Testing
- `pytest -q`
- `python -m py_compile app.py StockEval.py ticker_fetcher.py`


------
https://chatgpt.com/codex/tasks/task_e_687bfa302d88832f8e375ee6622ffb17