### PR TITLE
Add adjustable scoring weights modal

### DIFF
--- a/StockEval.py
+++ b/StockEval.py
@@ -134,8 +134,8 @@ def calculate_score(roce, interest_cov, gross_margin, net_margin, ccr, gp_assets
     score = 0
     score += max(min((roce / 0.15) * 30, 30), 0)
     score += max(min((interest_cov / 10) * 30, 30), 0)
-    score += max(min((gross_margin / 0.40) * 15, 15), 0)
-    score += max(min((net_margin / 0.15) * 15, 15), 0)
+    score += max(min((gross_margin / 0.40) * 15, 10), 0)
+    score += max(min((net_margin / 0.15) * 15, 10), 0)
     score += max(min((ccr / 0.90) * 10, 10), 0)
     score += max(min((gp_assets / 0.3) * 10, 10), 0)
     return min(round(score), 100)

--- a/static/script.js
+++ b/static/script.js
@@ -2,8 +2,8 @@
 const scoringWeights = {
     roce: 30,
     interestCov: 30,
-    grossMargin: 15,
-    netMargin: 15,
+    grossMargin: 10,
+    netMargin: 10,
     ccr: 10,
     gpAssets: 10
 };
@@ -382,12 +382,17 @@ function closeModal() {
 }
 
 // Close modal if clicking outside content
-document.getElementById("ai-modal").addEventListener("click", function (e) {
-    const content = document.getElementById("modal-content");
-    if (!content.contains(e.target)) {
-        closeModal();
-    }
-});
+function enableClickOutsideToClose(modalId, contentId, closeFn) {
+    const modal = document.getElementById(modalId);
+    const content = document.getElementById(contentId);
+    if (!modal || !content) return;
+
+    modal.addEventListener("click", function (e) {
+        if (!content.contains(e.target)) {
+            closeFn(); // e.g. closeModal() or your custom close
+        }
+    });
+}
 
 // Transition from initial view to results view, show export button
 window.showResults = function () {
@@ -502,6 +507,9 @@ function cycleQuotes() {
     showQuote(currentQuoteIndex);
     currentQuoteIndex = (currentQuoteIndex + 1) % quotes.length;
 }
+//Init
+enableClickOutsideToClose("ai-modal", "modal-content", closeModal);
+enableClickOutsideToClose("weight-modal", "weight-modal-content", closeWeightModal);
 
 cycleQuotes();
 setInterval(() => {

--- a/static/styles.css
+++ b/static/styles.css
@@ -190,7 +190,7 @@ button svg {
 
 #settings-btn {
   position: absolute;
-  top: 8px;
+  top: 18px;
   right: 8px;
   padding: 4px 8px;
   z-index: 20;

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,9 +50,6 @@
             <h2 style="display: inline-block;">My Watchlist</h2>
 
             <div id="watchlist">
-                <button id="settings-btn" onclick="openWeightModal()" title="Adjust scoring weights">
-                    ⚙
-                </button>
                 <table id="watchlist-table">
                     <thead>
                         <tr>
@@ -68,7 +65,15 @@
                             <th>Net Margin</th>
                             <th>Cash Conversion Ratio (FCF)</th>
                             <th>Gross Profit / Assets</th>
-                            <th>Score</th>
+                            <th style="min-width: 100px;">
+                                <div style="display: flex; align-items: center; gap: 12px; justify-content: center; padding-right: 20px">
+                                    Score
+                                    <button id="settings-btn" onclick="openWeightModal()" title="Adjust scoring weights" style="margin: 0; padding: 2px 8px;">
+                                    ⚙
+                                    </button>
+                                </div>
+                            </th>
+
                             <th>
                                 AI Analysis<br>
                                 <button onclick="runAllAI()">Run All</button>


### PR DESCRIPTION
## Summary
- add gear icon to watchlist header
- introduce scoring weight modal to adjust weights
- export scoring weights into Excel
- load scoring weights from Excel on import
- recalc scores on the client using new weights

## Testing
- `python -m py_compile StockEval.py app.py ticker_fetcher.py`

------
https://chatgpt.com/codex/tasks/task_e_687c1487f780832fa57bd92bfb76d7c1