### PR TITLE
Improve settings button integration

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,3 +1,112 @@
+// Default scoring weights
+const scoringWeights = {
+    roce: 30,
+    interestCov: 30,
+    grossMargin: 15,
+    netMargin: 15,
+    ccr: 10,
+    gpAssets: 10
+};
+
+function openWeightModal() {
+    document.getElementById('weight-roce').value = scoringWeights.roce;
+    document.getElementById('weight-interest').value = scoringWeights.interestCov;
+    document.getElementById('weight-gross').value = scoringWeights.grossMargin;
+    document.getElementById('weight-net').value = scoringWeights.netMargin;
+    document.getElementById('weight-ccr').value = scoringWeights.ccr;
+    document.getElementById('weight-gp').value = scoringWeights.gpAssets;
+    document.getElementById('weight-modal').style.display = 'flex';
+    updateWeightTotal();
+}
+
+function closeWeightModal() {
+    document.getElementById('weight-modal').style.display = 'none';
+}
+
+function getWeightTotal() {
+    return (
+        (parseFloat(document.getElementById('weight-roce').value) || 0) +
+        (parseFloat(document.getElementById('weight-interest').value) || 0) +
+        (parseFloat(document.getElementById('weight-gross').value) || 0) +
+        (parseFloat(document.getElementById('weight-net').value) || 0) +
+        (parseFloat(document.getElementById('weight-ccr').value) || 0) +
+        (parseFloat(document.getElementById('weight-gp').value) || 0)
+    );
+}
+
+function updateWeightTotal() {
+    const total = getWeightTotal();
+    updateWeightDonut(total);
+}
+
+function updateWeightDonut(total) {
+    const circle = document.querySelector('#weight-chart circle.progress');
+    const text = document.getElementById('weight-chart-text');
+    if (!circle || !text) return;
+    const radius = circle.r.baseVal.value;
+    const circumference = 2 * Math.PI * radius;
+    circle.style.strokeDasharray = `${circumference}`;
+    const offset = circumference - (total / 100) * circumference;
+    circle.style.strokeDashoffset = offset;
+    text.textContent = total;
+    circle.classList.remove('green','red','black');
+    if (total === 100) circle.classList.add('green');
+    else if (total > 100) circle.classList.add('red');
+    else circle.classList.add('black');
+}
+
+function saveWeights() {
+    const total = getWeightTotal();
+    if (total !== 100) {
+        showToast('Total weight must equal 100');
+        return;
+    }
+    scoringWeights.roce = parseFloat(document.getElementById('weight-roce').value) || 0;
+    scoringWeights.interestCov = parseFloat(document.getElementById('weight-interest').value) || 0;
+    scoringWeights.grossMargin = parseFloat(document.getElementById('weight-gross').value) || 0;
+    scoringWeights.netMargin = parseFloat(document.getElementById('weight-net').value) || 0;
+    scoringWeights.ccr = parseFloat(document.getElementById('weight-ccr').value) || 0;
+    scoringWeights.gpAssets = parseFloat(document.getElementById('weight-gp').value) || 0;
+    closeWeightModal();
+    updateScores();
+    showToast('Scores updated');
+}
+
+function parseMetric(val, isPercent) {
+    if (!val) return 0;
+    val = String(val).replace(/[%x]/g, '');
+    let num = parseFloat(val);
+    if (isNaN(num)) return 0;
+    return isPercent ? num / 100 : num;
+}
+
+function calculateScore(metrics) {
+    let score = 0;
+    score += Math.max(Math.min((metrics.roce / 0.15) * scoringWeights.roce, scoringWeights.roce), 0);
+    score += Math.max(Math.min((metrics.interestCov / 10) * scoringWeights.interestCov, scoringWeights.interestCov), 0);
+    score += Math.max(Math.min((metrics.grossMargin / 0.40) * scoringWeights.grossMargin, scoringWeights.grossMargin), 0);
+    score += Math.max(Math.min((metrics.netMargin / 0.15) * scoringWeights.netMargin, scoringWeights.netMargin), 0);
+    score += Math.max(Math.min((metrics.ccr / 0.90) * scoringWeights.ccr, scoringWeights.ccr), 0);
+    score += Math.max(Math.min((metrics.gpAssets / 0.3) * scoringWeights.gpAssets, scoringWeights.gpAssets), 0);
+    return Math.min(Math.round(score), 100);
+}
+
+function updateScores() {
+    document.querySelectorAll('#watchlist-body tr').forEach(row => {
+        const metrics = {
+            roce: parseFloat(row.dataset.roce || 0),
+            interestCov: parseFloat(row.dataset.interestcov || 0),
+            grossMargin: parseFloat(row.dataset.gross_margin || 0),
+            netMargin: parseFloat(row.dataset.net_margin || 0),
+            ccr: parseFloat(row.dataset.ccr || 0),
+            gpAssets: parseFloat(row.dataset.gp_assets || 0)
+        };
+        const score = calculateScore(metrics);
+        const cell = row.cells[12];
+        if (cell) cell.innerHTML = colorScore(`${score}/100`);
+    });
+}
+
 // Fetch stock suggestions as user types and display clickable suggestions
 async function searchTicker() {
     const query = document.getElementById("search").value;
@@ -54,7 +163,14 @@ async function evaluateStock(symbol) {
         const temp = document.createElement('tbody');
         temp.innerHTML = rowHtml;
         const rowNode = temp.firstElementChild;
+        rowNode.dataset.roce = parseMetric(data.ROCE, true);
+        rowNode.dataset.interestcov = parseMetric(data["Interest Coverage"], false);
+        rowNode.dataset.gross_margin = parseMetric(data["Gross Margin"], true);
+        rowNode.dataset.net_margin = parseMetric(data["Net Margin"], true);
+        rowNode.dataset.ccr = parseMetric(data["Cash Conversion Ratio (FCF)"], true);
+        rowNode.dataset.gp_assets = parseMetric(data["Gross Profit / Assets"], true);
         document.getElementById("watchlist-body").appendChild(rowNode);
+        updateScores();
     } catch (err) {
         console.error("Evaluation failed:", err);
     }
@@ -155,6 +271,29 @@ function importFromExcel(event) {
                 evaluateStock(symbol.trim());
             }
         });
+
+        const weightSheet = workbook.Sheets['Scoring Weight'];
+        if (weightSheet) {
+            const weights = XLSX.utils.sheet_to_json(weightSheet, {header:1});
+            const map = {
+                'ROCE': 'roce',
+                'Interest Coverage': 'interestCov',
+                'Gross Margin': 'grossMargin',
+                'Net Margin': 'netMargin',
+                'Cash Conversion Ratio': 'ccr',
+                'Gross Profit / Assets': 'gpAssets'
+            };
+            weights.forEach((row) => {
+                if (row.length >= 2 && map[row[0]]) {
+                    const val = parseFloat(row[1]);
+                    if (!isNaN(val)) {
+                        scoringWeights[map[row[0]]] = val;
+                    }
+                }
+            });
+            updateScores();
+            updateWeightDonut(getWeightTotal());
+        }
     };
     reader.readAsArrayBuffer(file);
 }
@@ -226,6 +365,19 @@ function exportToExcel() {
         const aiSheet = XLSX.utils.aoa_to_sheet(aiRows);
         XLSX.utils.book_append_sheet(wb, aiSheet, "Qualitative Analysis");
     }
+
+    // Scoring weights sheet
+    const weightRows = [
+        ["Metric", "Weight"],
+        ["ROCE", scoringWeights.roce],
+        ["Interest Coverage", scoringWeights.interestCov],
+        ["Gross Margin", scoringWeights.grossMargin],
+        ["Net Margin", scoringWeights.netMargin],
+        ["Cash Conversion Ratio", scoringWeights.ccr],
+        ["Gross Profit / Assets", scoringWeights.gpAssets]
+    ];
+    const weightSheet = XLSX.utils.aoa_to_sheet(weightRows);
+    XLSX.utils.book_append_sheet(wb, weightSheet, "Scoring Weight");
 
     XLSX.writeFile(wb, "watchlist.xlsx");
 }
@@ -373,3 +525,19 @@ setInterval(() => {
         cycleQuotes();
     }, 1000); // fade out 1s, fade in 0.5s inside showQuote
 }, 10000); // every 10 seconds
+
+function showToast(msg) {
+    const toast = document.getElementById('toast');
+    if (!toast) return;
+    toast.textContent = msg;
+    toast.classList.add('show');
+    clearTimeout(showToast._timeout);
+    showToast._timeout = setTimeout(() => {
+        toast.classList.remove('show');
+    }, 10000);
+}
+
+// update total weight when inputs change
+document.querySelectorAll('#weight-modal input[type="number"]').forEach(inp => {
+    inp.addEventListener('input', updateWeightTotal);
+});

--- a/static/styles.css
+++ b/static/styles.css
@@ -91,6 +91,7 @@ span {
 
 /* ==== Watchlist Table ==== */
 #watchlist {
+  position: relative;
   max-height: 750px;
   overflow-y: auto;
   border: 1px solid #1e1e1e;
@@ -185,6 +186,14 @@ button svg {
   fill: currentColor;
   margin-right: 6px;
   transition: fill 0.3s ease;
+}
+
+#settings-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 4px 8px;
+  z-index: 20;
 }
 
 button:focus-visible {
@@ -290,6 +299,44 @@ input[type="text"]:focus,
   box-sizing: border-box;
 }
 
+#weight-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+#weight-modal-content {
+  background: #ffffff;
+  color: #1e1e1e !important;
+  border-radius: 12px;
+  padding: 25px 30px;
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 10px 40px rgba(26, 26, 26, 1);
+  position: relative;
+  font-family: Arial, sans-serif;
+}
+
+#weight-modal-content label {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  color: #1e1e1e;
+}
+
+#weight-modal-content input[type="number"] {
+  color: #1e1e1e;
+  text-align: right;
+  width: 70px;
+}
+
+
 #ai-modal-content {
   background: #ffffff;
   color: #1e1e1e !important;
@@ -360,4 +407,71 @@ input[type="text"]:focus,
   max-width: 400px;
   text-align: center;
   user-select: none;
+}
+
+/* ==== Toast Notification ==== */
+#toast {
+  position: fixed;
+  top: -60px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1e1e1e;
+  color: #ffffff;
+  padding: 10px 20px;
+  border-radius: 6px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  font-family: Arial, sans-serif;
+  z-index: 5000;
+  transition: top 0.5s ease;
+}
+
+#toast.show {
+  top: 20px;
+}
+
+/* ==== Weight Donut ==== */
+#weight-chart {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 10px;
+}
+
+#weight-chart svg {
+  width: 80px;
+  height: 80px;
+  transform: rotate(-90deg);
+}
+
+#weight-chart circle {
+  fill: none;
+  stroke-width: 10;
+}
+
+#weight-chart circle.bg {
+  stroke: #e0e0e0;
+}
+
+#weight-chart circle.progress {
+  stroke: #000;
+  stroke-dasharray: 283;
+  stroke-dashoffset: 283;
+  transition: stroke-dashoffset 0.4s ease;
+}
+
+#weight-chart circle.progress.green {
+  stroke: #28a745;
+}
+
+#weight-chart circle.progress.red {
+  stroke: red;
+}
+
+#weight-chart circle.progress.black {
+  stroke: #000;
+}
+
+#weight-chart text {
+  transform: rotate(90deg);
+  font-size: 18px;
+  fill: #1e1e1e;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,9 +47,12 @@
 
         <!-- Watchlist / Results view -->
         <div id="results-view" style="display: none;">
-            <h2>My Watchlist</h2>
+            <h2 style="display: inline-block;">My Watchlist</h2>
 
             <div id="watchlist">
+                <button id="settings-btn" onclick="openWeightModal()" title="Adjust scoring weights">
+                    ⚙
+                </button>
                 <table id="watchlist-table">
                     <thead>
                         <tr>
@@ -88,8 +91,38 @@
             </div>
         </div>
 
+        <!-- Scoring weight modal -->
+        <div id="weight-modal">
+            <div id="weight-modal-content">
+                <button class="modal-close" onclick="closeWeightModal()">✖</button>
+                <h3>Adjust Scoring Weights</h3>
+                <div class="weight-inputs">
+                    <label>ROCE <input type="number" id="weight-roce" oninput="updateWeightTotal()"></label>
+                    <label>Interest Coverage <input type="number" id="weight-interest" oninput="updateWeightTotal()"></label>
+                    <label>Gross Margin <input type="number" id="weight-gross" oninput="updateWeightTotal()"></label>
+                    <label>Net Margin <input type="number" id="weight-net" oninput="updateWeightTotal()"></label>
+                    <label>Cash Conversion Ratio <input type="number" id="weight-ccr" oninput="updateWeightTotal()"></label>
+                    <label>Gross Profit / Assets <input type="number" id="weight-gp" oninput="updateWeightTotal()"></label>
+                </div>
+                <div id="weight-chart">
+                    <svg viewBox="0 0 100 100">
+                        <circle class="bg" cx="50" cy="50" r="45"></circle>
+                        <circle class="progress" cx="50" cy="50" r="45"></circle>
+                        <text id="weight-chart-text" x="50" y="55" text-anchor="middle">0</text>
+                    </svg>
+                </div>
+                <button onclick="saveWeights()">
+                    <svg viewBox="0 0 24 24" width="12" height="12">
+                        <path d="M17 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zM12 19c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm2-10H6V5h8v4z"/>
+                    </svg>
+                    Save
+                </button>
+            </div>
+        </div>
+
     </div>
 
+    <div id="toast"></div>
     <script src="{{ url_for('static', filename='script.js') }}"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- integrate weight settings button with table layout
- add floppy disk icon to save weights button
- position settings button over the watchlist table
- keep recalculation of scores on weight save
- show toast notification when scores update
- display weight total as donut chart with dynamic colors

## Testing
- `python -m py_compile StockEval.py app.py ticker_fetcher.py`


------
https://chatgpt.com/codex/tasks/task_e_687c1487f780832fa57bd92bfb76d7c1