### PR TITLE
Fix price column sorting

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -85,7 +85,8 @@ function saveWeights() {
 
 function parseMetric(val, isPercent) {
     if (!val) return 0;
-    val = String(val).replace(/[%x]/g, '');
+    // Remove percentage signs, multiplier x, dollar signs and commas
+    val = String(val).replace(/[%,x$]/g, '').replace(/,/g, '');
     let num = parseFloat(val);
     if (isNaN(num)) return 0;
     return isPercent ? num / 100 : num;


### PR DESCRIPTION
## Summary
- fix price sorting by stripping $ and commas when parsing metrics

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d72744e7c832f97b1fc2216fde017