### PR TITLE
Add clear option in weight modal

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -45,6 +45,14 @@ function updateWeightTotal() {
     updateWeightDonut(total);
 }
 
+/** Clear all weight inputs in the modal */
+function clearWeightInputs() {
+    document.querySelectorAll('#weight-modal input[type="number"]').forEach(inp => {
+        inp.value = '';
+    });
+    updateWeightTotal();
+}
+
 /** Animate and color the donut chart in modal */
 function updateWeightDonut(total) {
     const circle = document.querySelector('#weight-chart circle.progress');

--- a/static/styles.css
+++ b/static/styles.css
@@ -475,12 +475,17 @@ input[type="number"]:focus,
   margin-top: 24px;
 }
 
-/* Container: donut chart left, save button right */
 #weight-chart-container {
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+}
+/* Buttons next to donut chart */
+#weight-buttons {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
 }
 #weight-chart {
   display: flex;

--- a/templates/index.html
+++ b/templates/index.html
@@ -255,14 +255,22 @@
                                 dominant-baseline="middle">87</text>
                         </svg>
                     </div>
-                    <!-- Save button for weights -->
-                    <button onclick="saveWeights()">
-                        <svg viewBox="0 0 24 24" width="12" height="12">
-                            <path
-                                d="M17 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zM12 19c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm2-10H6V5h8v4z" />
-                        </svg>
-                        Save
-                    </button>
+                    <!-- Action buttons -->
+                    <div id="weight-buttons">
+                        <button id="clear-weight-btn" onclick="clearWeightInputs()">
+                            <svg viewBox="0 0 24 24" width="12" height="12">
+                                <path d="M3 6h18v2H3zm2 3h14v2H5zm2 3h10v2H7z" />
+                            </svg>
+                            Clear
+                        </button>
+                        <button onclick="saveWeights()">
+                            <svg viewBox="0 0 24 24" width="12" height="12">
+                                <path
+                                    d="M17 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zM12 19c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm2-10H6V5h8v4z" />
+                            </svg>
+                            Save
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add `Clear` button in the weight modal next to `Save`
- add style rules for new button layout
- support clearing input values in `script.js`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d79bf87e4832fbb59b0c3e7ee26b0