### PR TITLE
Enable metric removal and new scoring options

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -405,6 +405,97 @@ input[type="number"]:focus,
   margin-bottom: 8px;
   color: #1e1e1e;
 }
+
+.weight-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.weight-item label {
+  flex: 1 1 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #1e1e1e !important;
+}
+.weight-item .metric-name {
+  color: #1e1e1e !important;
+  position: relative;
+}
+.weight-item .metric-name::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 2px;
+  background: #ff0000;
+  transform-origin: left;
+  transform: scaleX(0);
+  transition: transform 0.3s ease;
+}
+.weight-item .metric-name.deleted::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+.weight-item .metric-name.reverse::after {
+  transform-origin: right;
+}
+.weight-toggle {
+  margin-right: 8px;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: transform 0.3s ease;
+}
+.weight-toggle .bar {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 14px;
+  height: 2px;
+  background: #1e1e1e;
+  transform-origin: center;
+  transition: transform 0.3s ease;
+}
+.weight-toggle.delete .bar:first-child {
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+.weight-toggle.delete .bar:last-child {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+.weight-toggle.add .bar:first-child {
+  transform: translate(-50%, -50%) rotate(0deg);
+}
+.weight-toggle.add .bar:last-child {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+
+.weight-toggle.rotate-cw {
+  animation: rotateCW 0.3s linear;
+}
+
+.weight-toggle.rotate-ccw {
+  animation: rotateCCW 0.3s linear;
+}
+
+@keyframes rotateCW {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes rotateCCW {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(-360deg); }
+}
 #weight-modal-content input[type="number"] {
   padding: 6px 10px;
   text-align: right;

--- a/templates/index.html
+++ b/templates/index.html
@@ -111,7 +111,7 @@
                                 </div>
                             </th>
                             <!-- Dividend yield column -->
-                            <th title="Annual dividends as a percent of price">
+                            <th title="Annual dividends as a percent of price" class="col-dividend_yield">
                                 <div class="th-label">
                                     Dividend Yield
                                     <span class="sort-arrows">
@@ -121,7 +121,7 @@
                                 </div>
                             </th>
                             <!-- P/E Ratio -->
-                            <th title="Price to earnings ratio">
+                            <th title="Price to earnings ratio" class="col-pe_ratio">
                                 <div class="th-label">
                                     P/E Ratio
                                     <span class="sort-arrows">
@@ -131,7 +131,7 @@
                                 </div>
                             </th>
                             <!-- ROCE (Return on Capital Employed) -->
-                            <th
+                            <th class="col-roce"
                                 title="-Return on Capital Employed  &#10-ROCE above 15% may indicate better profitability">
                                 <div class="th-label">
                                     ROCE
@@ -142,7 +142,7 @@
                                 </div>
                             </th>
                             <!-- Interest Coverage -->
-                            <th
+                            <th class="col-interestcov"
                                 title="-Measures the ability to cover interest  &#10-A ratio of 10x suggests a more controlled financial position">
                                 <div class="th-label">
                                     Interest Coverage
@@ -153,7 +153,7 @@
                                 </div>
                             </th>
                             <!-- Gross Margin -->
-                            <th
+                            <th class="col-gross_margin"
                                 title="-Gross profit as a percent of revenue &#10-A margin above 30% may indicate a stronger competitive postion">
                                 <div class="th-label">
                                     Gross Margin
@@ -164,7 +164,7 @@
                                 </div>
                             </th>
                             <!-- Net Margin -->
-                            <th
+                            <th class="col-net_margin"
                                 title="-Portion of revenue that exceeds all expenses &#10-A net margin above 15% suggests a greater ability of generating net income">
                                 <div class="th-label">
                                     Net Margin
@@ -175,7 +175,7 @@
                                 </div>
                             </th>
                             <!-- Cash Conversion Ratio (FCF) -->
-                            <th
+                            <th class="col-ccr"
                                 title="-How efficiently a company is converting its income into free cash flo w&#10-A higher FCF can suggest dividend increases, buyback programs">
                                 <div class="th-label">
                                     Cash Conversion Ratio (FCF)
@@ -186,7 +186,7 @@
                                 </div>
                             </th>
                             <!-- Gross Profit / Assets -->
-                            <th
+                            <th class="col-gp_assets"
                                 title="-Gross profit relative to total assets &#10;-Shows how efficiently a company uses its assets to generate profit">
                                 <div class="th-label">
                                     Gross Profit / Assets
@@ -249,15 +249,54 @@
                 </div>
                 <!-- Inputs for custom score weighting -->
                 <div class="weight-inputs">
-                    <label>ROCE <input type="number" id="weight-roce" oninput="updateWeightTotal()"></label>
-                    <label>Interest Coverage <input type="number" id="weight-interest"
-                            oninput="updateWeightTotal()"></label>
-                    <label>Gross Margin <input type="number" id="weight-gross" oninput="updateWeightTotal()"></label>
-                    <label>Net Margin <input type="number" id="weight-net" oninput="updateWeightTotal()"></label>
-                    <label>Cash Conversion Ratio <input type="number" id="weight-ccr"
-                            oninput="updateWeightTotal()"></label>
-                    <label>Gross Profit / Assets <input type="number" id="weight-gp"
-                            oninput="updateWeightTotal()"></label>
+                    <div class="weight-item" data-key="roce" id="row-roce">
+                        <button class="weight-toggle delete" onclick="toggleWeight('roce')">
+                            <span class="bar"></span><span class="bar"></span>
+                        </button>
+                        <label><span class="metric-name">ROCE</span> <input type="number" id="weight-roce" oninput="updateWeightTotal()"></label>
+                    </div>
+                    <div class="weight-item" data-key="interestCov" id="row-interestCov">
+                        <button class="weight-toggle delete" onclick="toggleWeight('interestCov')">
+                            <span class="bar"></span><span class="bar"></span>
+                        </button>
+                        <label><span class="metric-name">Interest Coverage</span> <input type="number" id="weight-interest" oninput="updateWeightTotal()"></label>
+                    </div>
+                    <div class="weight-item" data-key="grossMargin" id="row-grossMargin">
+                        <button class="weight-toggle delete" onclick="toggleWeight('grossMargin')">
+                            <span class="bar"></span><span class="bar"></span>
+                        </button>
+                        <label><span class="metric-name">Gross Margin</span> <input type="number" id="weight-gross" oninput="updateWeightTotal()"></label>
+                    </div>
+                    <div class="weight-item" data-key="netMargin" id="row-netMargin">
+                        <button class="weight-toggle delete" onclick="toggleWeight('netMargin')">
+                            <span class="bar"></span><span class="bar"></span>
+                        </button>
+                        <label><span class="metric-name">Net Margin</span> <input type="number" id="weight-net" oninput="updateWeightTotal()"></label>
+                    </div>
+                    <div class="weight-item" data-key="ccr" id="row-ccr">
+                        <button class="weight-toggle delete" onclick="toggleWeight('ccr')">
+                            <span class="bar"></span><span class="bar"></span>
+                        </button>
+                        <label><span class="metric-name">Cash Conversion Ratio</span> <input type="number" id="weight-ccr" oninput="updateWeightTotal()"></label>
+                    </div>
+                    <div class="weight-item" data-key="gpAssets" id="row-gpAssets">
+                        <button class="weight-toggle delete" onclick="toggleWeight('gpAssets')">
+                            <span class="bar"></span><span class="bar"></span>
+                        </button>
+                        <label><span class="metric-name">Gross Profit / Assets</span> <input type="number" id="weight-gp" oninput="updateWeightTotal()"></label>
+                    </div>
+                    <div class="weight-item" data-key="peRatio" id="row-peRatio">
+                        <button class="weight-toggle delete" onclick="toggleWeight('peRatio')">
+                            <span class="bar"></span><span class="bar"></span>
+                        </button>
+                        <label><span class="metric-name">P/E Ratio</span> <input type="number" id="weight-pe" oninput="updateWeightTotal()"></label>
+                    </div>
+                    <div class="weight-item" data-key="dividendYield" id="row-dividendYield">
+                        <button class="weight-toggle delete" onclick="toggleWeight('dividendYield')">
+                            <span class="bar"></span><span class="bar"></span>
+                        </button>
+                        <label><span class="metric-name">Dividend Yield</span> <input type="number" id="weight-div" oninput="updateWeightTotal()"></label>
+                    </div>
                 </div>
                 <!-- Donut chart for visualizing weights -->
                 <div id="weight-chart-container">


### PR DESCRIPTION
## Summary
- add PE ratio and dividend yield to scoring weights
- allow delete/add toggles for weight rows in modal
- adjust default weights and scoring algorithm
- support updated weights in Excel import/export
- update Python scoring to handle new metrics
- **fix weight row removal and NaN calculation**
- add animations for add/delete toggle and strikethrough
- use reverse animation when toggling between delete and add states

## Testing
- `python -m py_compile StockEval.py app.py ticker_fetcher.py`

------
https://chatgpt.com/codex/tasks/task_e_688521d20278832f8e4313d577ed6d63