### PR TITLE
Add Lottie animation for weight toggles

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -455,6 +455,11 @@ input[type="number"]:focus,
   cursor: pointer;
   transition: transform 0.3s ease;
 }
+.weight-toggle .lottie {
+  width: 20px;
+  height: 20px;
+  pointer-events: none;
+}
 
 .weight-toggle.rotate-cw {
   animation: rotateCW 0.3s linear;

--- a/static/styles.css
+++ b/static/styles.css
@@ -445,8 +445,8 @@ input[type="number"]:focus,
 .weight-toggle {
   margin-right: 8px;
   flex: 0 0 auto;
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -456,8 +456,8 @@ input[type="number"]:focus,
   transition: transform 0.3s ease;
 }
 .weight-toggle .lottie {
-  width: 28px;
-  height: 28px;
+  width: 36px;
+  height: 36px;
   pointer-events: none;
 }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -445,8 +445,8 @@ input[type="number"]:focus,
 .weight-toggle {
   margin-right: 8px;
   flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
+  width: 32px;
+  height: 32px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -456,8 +456,8 @@ input[type="number"]:focus,
   transition: transform 0.3s ease;
 }
 .weight-toggle .lottie {
-  width: 20px;
-  height: 20px;
+  width: 28px;
+  height: 28px;
   pointer-events: none;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- SheetJS for Excel export/import -->
     <script src="https://cdn.sheetjs.com/xlsx-latest/package/dist/xlsx.full.min.js"></script>
+    <!-- Lottie for animated add/delete button -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.10.2/lottie.min.js"></script>
     <title>Stock Watchlist</title>
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='icons/website-icon.png') }}">
     <!-- Custom CSS -->
@@ -250,35 +252,51 @@
                 <!-- Inputs for custom score weighting -->
                 <div class="weight-inputs">
                     <div class="weight-item" data-key="roce" id="row-roce">
-                        <button class="weight-toggle" onclick="toggleWeight('roce')">❌</button>
+                        <button class="weight-toggle" onclick="toggleWeight('roce')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                            <div class="lottie"></div>
+                        </button>
                         <label><span class="metric-name">ROCE</span> <input type="number" id="weight-roce" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="interestCov" id="row-interestCov">
-                        <button class="weight-toggle" onclick="toggleWeight('interestCov')">❌</button>
+                        <button class="weight-toggle" onclick="toggleWeight('interestCov')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                            <div class="lottie"></div>
+                        </button>
                         <label><span class="metric-name">Interest Coverage</span> <input type="number" id="weight-interest" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="grossMargin" id="row-grossMargin">
-                        <button class="weight-toggle" onclick="toggleWeight('grossMargin')">❌</button>
+                        <button class="weight-toggle" onclick="toggleWeight('grossMargin')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                            <div class="lottie"></div>
+                        </button>
                         <label><span class="metric-name">Gross Margin</span> <input type="number" id="weight-gross" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="netMargin" id="row-netMargin">
-                        <button class="weight-toggle" onclick="toggleWeight('netMargin')">❌</button>
+                        <button class="weight-toggle" onclick="toggleWeight('netMargin')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                            <div class="lottie"></div>
+                        </button>
                         <label><span class="metric-name">Net Margin</span> <input type="number" id="weight-net" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="ccr" id="row-ccr">
-                        <button class="weight-toggle" onclick="toggleWeight('ccr')">❌</button>
+                        <button class="weight-toggle" onclick="toggleWeight('ccr')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                            <div class="lottie"></div>
+                        </button>
                         <label><span class="metric-name">Cash Conversion Ratio</span> <input type="number" id="weight-ccr" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="gpAssets" id="row-gpAssets">
-                        <button class="weight-toggle" onclick="toggleWeight('gpAssets')">❌</button>
+                        <button class="weight-toggle" onclick="toggleWeight('gpAssets')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                            <div class="lottie"></div>
+                        </button>
                         <label><span class="metric-name">Gross Profit / Assets</span> <input type="number" id="weight-gp" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="peRatio" id="row-peRatio">
-                        <button class="weight-toggle" onclick="toggleWeight('peRatio')">❌</button>
+                        <button class="weight-toggle" onclick="toggleWeight('peRatio')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                            <div class="lottie"></div>
+                        </button>
                         <label><span class="metric-name">P/E Ratio</span> <input type="number" id="weight-pe" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="dividendYield" id="row-dividendYield">
-                        <button class="weight-toggle" onclick="toggleWeight('dividendYield')">❌</button>
+                        <button class="weight-toggle" onclick="toggleWeight('dividendYield')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                            <div class="lottie"></div>
+                        </button>
                         <label><span class="metric-name">Dividend Yield</span> <input type="number" id="weight-div" oninput="updateWeightTotal()"></label>
                     </div>
                 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -252,51 +252,51 @@
                 <!-- Inputs for custom score weighting -->
                 <div class="weight-inputs">
                     <div class="weight-item" data-key="roce" id="row-roce">
-                        <button class="weight-toggle" onclick="toggleWeight('roce')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                        <div class="weight-toggle" onclick="toggleWeight('roce')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
                             <div class="lottie"></div>
-                        </button>
+                        </div>
                         <label><span class="metric-name">ROCE</span> <input type="number" id="weight-roce" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="interestCov" id="row-interestCov">
-                        <button class="weight-toggle" onclick="toggleWeight('interestCov')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                        <div class="weight-toggle" onclick="toggleWeight('interestCov')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
                             <div class="lottie"></div>
-                        </button>
+                        </div>
                         <label><span class="metric-name">Interest Coverage</span> <input type="number" id="weight-interest" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="grossMargin" id="row-grossMargin">
-                        <button class="weight-toggle" onclick="toggleWeight('grossMargin')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                        <div class="weight-toggle" onclick="toggleWeight('grossMargin')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
                             <div class="lottie"></div>
-                        </button>
+                        </div>
                         <label><span class="metric-name">Gross Margin</span> <input type="number" id="weight-gross" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="netMargin" id="row-netMargin">
-                        <button class="weight-toggle" onclick="toggleWeight('netMargin')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                        <div class="weight-toggle" onclick="toggleWeight('netMargin')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
                             <div class="lottie"></div>
-                        </button>
+                        </div>
                         <label><span class="metric-name">Net Margin</span> <input type="number" id="weight-net" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="ccr" id="row-ccr">
-                        <button class="weight-toggle" onclick="toggleWeight('ccr')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                        <div class="weight-toggle" onclick="toggleWeight('ccr')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
                             <div class="lottie"></div>
-                        </button>
+                        </div>
                         <label><span class="metric-name">Cash Conversion Ratio</span> <input type="number" id="weight-ccr" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="gpAssets" id="row-gpAssets">
-                        <button class="weight-toggle" onclick="toggleWeight('gpAssets')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                        <div class="weight-toggle" onclick="toggleWeight('gpAssets')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
                             <div class="lottie"></div>
-                        </button>
+                        </div>
                         <label><span class="metric-name">Gross Profit / Assets</span> <input type="number" id="weight-gp" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="peRatio" id="row-peRatio">
-                        <button class="weight-toggle" onclick="toggleWeight('peRatio')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                        <div class="weight-toggle" onclick="toggleWeight('peRatio')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
                             <div class="lottie"></div>
-                        </button>
+                        </div>
                         <label><span class="metric-name">P/E Ratio</span> <input type="number" id="weight-pe" oninput="updateWeightTotal()"></label>
                     </div>
                     <div class="weight-item" data-key="dividendYield" id="row-dividendYield">
-                        <button class="weight-toggle" onclick="toggleWeight('dividendYield')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
+                        <div class="weight-toggle" onclick="toggleWeight('dividendYield')" data-lottie="{{ url_for('static', filename='icons/add-delete.json') }}">
                             <div class="lottie"></div>
-                        </button>
+                        </div>
                         <label><span class="metric-name">Dividend Yield</span> <input type="number" id="weight-div" oninput="updateWeightTotal()"></label>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- include lottie-web in `index.html`
- use lottie add/delete animation for weight toggle buttons
- style lottie container
- initialize and control animations in `script.js`

## Testing
- `python -m py_compile StockEval.py app.py ticker_fetcher.py`

------
https://chatgpt.com/codex/tasks/task_e_688547e047c0832f98eebfe2c196454b