### PR TITLE
Align score modal buttons and remove rotation

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -75,12 +75,13 @@ function toggleWeight(key) {
             nameSpan.classList.remove('deleted');
             setTimeout(() => nameSpan.classList.remove('reverse'), 300);
         }
-        setTimeout(() => { btn.textContent = '❌'; }, 150);
+        setTimeout(() => { btn.innerHTML = '<span class="x-icon">❌</span>'; }, 150);
+
         input.value = row.dataset.prev || 0;
     } else {
         row.classList.add('deleted');
         if (nameSpan) nameSpan.classList.add('deleted');
-        setTimeout(() => { btn.textContent = '+'; }, 150);
+        setTimeout(() => { btn.innerHTML = '<span class="green-plus">+</span>'; }, 150);
         row.dataset.prev = input.value;
         input.value = 0;
     }

--- a/static/script.js
+++ b/static/script.js
@@ -68,10 +68,7 @@ function toggleWeight(key) {
     const input = row.querySelector('input');
     const nameSpan = row.querySelector('.metric-name');
     const btn = row.querySelector('.weight-toggle');
-    btn.classList.remove('rotate-cw', 'rotate-ccw');
-    void btn.offsetWidth; // restart animation
     if (row.classList.contains('deleted')) {
-        btn.classList.add('rotate-ccw');
         row.classList.remove('deleted');
         if (nameSpan) {
             nameSpan.classList.add('reverse');
@@ -81,7 +78,6 @@ function toggleWeight(key) {
         setTimeout(() => { btn.textContent = '❌'; }, 150);
         input.value = row.dataset.prev || 0;
     } else {
-        btn.classList.add('rotate-cw');
         row.classList.add('deleted');
         if (nameSpan) nameSpan.classList.add('deleted');
         setTimeout(() => { btn.textContent = '+'; }, 150);

--- a/static/styles.css
+++ b/static/styles.css
@@ -452,6 +452,7 @@ input[type="number"]:focus,
   border: 1px solid #ccc;
   border-radius: 4px;
   cursor: pointer;
+  margin-top: -8px;
 }
 #weight-modal-content input[type="number"] {
   padding: 6px 10px;
@@ -465,6 +466,20 @@ input[type="number"]:focus,
   -webkit-appearance: none;
   margin: 0;
 }
+
+.x-icon {
+  display: inline-block;
+  margin-top: -1px; 
+  font-size: 16px;
+  line-height: 1;
+}
+.green-plus {
+  color: green;
+  font-size: 32px; 
+  font-weight: bold;
+  line-height: 1;
+}
+
 
 /* Modal close button (X) */
 .modal-close {

--- a/static/styles.css
+++ b/static/styles.css
@@ -408,9 +408,9 @@ input[type="number"]:focus,
 
 .weight-item {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   margin-bottom: 8px;
+  gap: 8px;
 }
 .weight-item label {
   flex: 1 1 auto;
@@ -443,35 +443,15 @@ input[type="number"]:focus,
   transform-origin: right;
 }
 .weight-toggle {
-  margin-right: 8px;
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
   border: 1px solid #ccc;
   border-radius: 4px;
   cursor: pointer;
-  transition: transform 0.3s ease;
-}
-
-.weight-toggle.rotate-cw {
-  animation: rotateCW 0.3s linear;
-}
-
-.weight-toggle.rotate-ccw {
-  animation: rotateCCW 0.3s linear;
-}
-
-@keyframes rotateCW {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-@keyframes rotateCCW {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(-360deg); }
 }
 #weight-modal-content input[type="number"] {
   padding: 6px 10px;


### PR DESCRIPTION
## Summary
- Align delete/add buttons with weight labels in the scoring modal
- Remove button rotation animation and related keyframes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ecc0dcd74832f92a5556fcb590879