### PR TITLE
Improve mobile card labels and button styling

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -320,7 +320,7 @@ function removeRow(symbol) {
 // Run AI qualitative analysis for a single row
 async function runAIForRow(symbol, btn) {
     btn.disabled = true;
-    btn.innerHTML = `<img src="static/icons/loading.gif" alt="Loading" style="width:16px; height:16px;">`;
+    btn.innerHTML = `<img src="static/icons/loading.gif" alt="Loading" style="width:25px; height:25px;">`;
     try {
         const res = await fetch("/run_qualitative", {
             method: "POST",
@@ -334,7 +334,13 @@ async function runAIForRow(symbol, btn) {
             return;
         }
         const cleanText = data[0].Qualitative.replace(/<br\s*\/?>/gi, "<br>");
-        btn.innerText = "View";
+        btn.innerHTML = `
+            <svg viewBox="0 0 24 24" width="50" height="50" fill="white" xmlns="http://www.w3.org/2000/svg">
+            <path d="M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42L17.59 5H14V3z"/>
+            <path d="M5 5h5V3H5c-1.1 0-2 .9-2 2v5h2V5z"/>
+            <path d="M19 19h-5v2h5c1.1 0 2-.9 2-2v-5h-2v5z"/>
+            <path d="M5 19v-5H3v5c0 1.1.9 2 2 2h5v-2H5z"/>
+            </svg>`;
         btn.disabled = false;
         btn.dataset.analysis = cleanText;
         btn.onclick = () => showModal(`${symbol} AI Analysis`, cleanText);
@@ -590,15 +596,13 @@ function buildRow(data) {
         const cls = classMap[key] || key.toLowerCase().replace(/\s+|\//g, '_');
         row += `<td data-label="${key}" class="col-${cls}">${val}</td>`;
     });
-    row += `<td class="ai-cell"><button class="ai-button" onclick="runAIForRow('${data.Symbol}', this)">
-            <svg viewBox="0 0 24 24" width="16" height="16"><polygon points="8,5 8,19 19,12" fill="white"/></svg>
-        </button></td>`;
-    row += `<td class="delete-cell"><button class="delete-button" onclick="removeRow('${data.Symbol}')">
-            <svg viewBox="0 0 24 24" width="16" height="16" stroke="white" stroke-width="2" fill="none">
-                <line x1="18" y1="6" x2="6" y2="18" />
-                <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-        </button></td>`;
+    row += `<td class="ai-cell">
+        <button class="ai-button" onclick="runAIForRow('${data.Symbol}', this)">
+            ▶
+        </button>
+    </td>`;
+
+    row += `<td class="delete-cell"><button class="delete-button" onclick="removeRow('${data.Symbol}')">❌</button></td>`;
     row += "</tr>";
     return row;
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -292,6 +292,8 @@ td button {
 /* Icon-only buttons for run/delete actions */
 .ai-button,
 .delete-button {
+  width: 60px;
+  font-size: 20px;
   background: none;
   border: none;
   padding: 0;
@@ -300,7 +302,11 @@ td button {
   justify-content: center;
   color: white;
 }
-
+.ai-button svg {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+}
 .ai-button:hover:not(:disabled),
 .delete-button:hover:not(:disabled) {
   background: none;
@@ -317,8 +323,8 @@ td button {
 .ai-button svg,
 .ai-button img,
 .delete-button svg {
-  width: 16px;
-  height: 16px;
+  width: 30px;
+  height: 30px;
   display: block;
   margin-right: 0;
 }
@@ -477,16 +483,16 @@ input[type="number"]:focus,
   transform-origin: right;
 }
 .weight-toggle {
+  font-size: 20px;
+  background: none;
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  cursor: pointer;
-  margin-top: -8px;
+  border: none;
+  margin-top: -12px;
 }
 #weight-modal-content input[type="number"] {
   padding: 6px 10px;
@@ -504,12 +510,12 @@ input[type="number"]:focus,
 .x-icon {
   display: inline-block;
   margin-top: -1px; 
-  font-size: 16px;
+  font-size: 20px;
   line-height: 1;
 }
 .green-plus {
   color: green;
-  font-size: 32px; 
+  font-size: 40px; 
   font-weight: bold;
   line-height: 1;
 }


### PR DESCRIPTION
## Summary
- Show metric labels above values on mobile cards
- Replace run button with white play icon and remove button backgrounds
- Position delete button at the top-right of mobile cards

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ed6322358832fb61bf288606b941f