### PR TITLE
Fix cash conversion ratio and clean export

### DIFF
--- a/StockEval.py
+++ b/StockEval.py
@@ -104,14 +104,22 @@ def calc_cash_conversion_ratio_ttm(ticker_obj):
     Calculate Cash Conversion Ratio (TTM): Operating Cash Flow / Net Income
     """
     try:
-        cashflow = ticker_obj.cashflow
-        financials = ticker_obj.financials
-        if cashflow is None or financials is None:
+        cf_q = ticker_obj.quarterly_cashflow
+        fin_q = ticker_obj.quarterly_financials
+        if cf_q is None or fin_q is None or cf_q.empty or fin_q.empty:
             return 0
-        cfo = cashflow.loc['Operating Cash Flow'].iloc[0] if 'Operating Cash Flow' in cashflow.index else 0
-        ni = financials.loc['Net Income'].iloc[0] if 'Net Income' in financials.index else 0
+        cfo = (
+            cf_q.loc['Operating Cash Flow'].iloc[:4].sum()
+            if 'Operating Cash Flow' in cf_q.index
+            else 0
+        )
+        ni = (
+            fin_q.loc['Net Income'].iloc[:4].sum()
+            if 'Net Income' in fin_q.index
+            else 0
+        )
         return cfo / ni if ni else 0
-    except:
+    except Exception:
         return 0
 
 def calc_pe_ratio(ticker_obj):

--- a/static/script.js
+++ b/static/script.js
@@ -506,6 +506,11 @@ function exportToExcel() {
     const originalTable = document.getElementById("watchlist-table");
     const clonedTable = originalTable.cloneNode(true);
 
+    // Remove sort arrows and settings button
+    clonedTable.querySelectorAll('.sort-arrows').forEach(el => el.remove());
+    const settingsBtn = clonedTable.querySelector('#settings-btn');
+    if (settingsBtn) settingsBtn.remove();
+
     // Remove last "Delete" column and AI column
     const headerRow = clonedTable.querySelector("thead tr");
     if (headerRow) headerRow.removeChild(headerRow.lastElementChild);


### PR DESCRIPTION
## Summary
- compute cash conversion ratio using trailing twelve-month quarterly data
- remove sort arrows and settings button when exporting watchlist table

## Testing
- `python -m py_compile StockEval.py app.py ticker_fetcher.py`


------
https://chatgpt.com/codex/tasks/task_e_688fc2f3377c832f8669b07cd9b146ae