### PR TITLE
Align mobile UI elements

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -286,8 +286,10 @@ function sortTable(column, asc) {
 
 // Live search for tickers and show suggestion dropdown
 async function searchTicker() {
-    const query = document.getElementById("search").value;
+    const searchInput = document.getElementById("search");
+    const query = searchInput.value;
     const suggestionsDiv = document.getElementById("suggestions");
+    suggestionsDiv.style.width = `${searchInput.offsetWidth}px`;
     if (query.length < 1) {
         suggestionsDiv.innerHTML = '';
         return;
@@ -298,6 +300,7 @@ async function searchTicker() {
     data.forEach(stock => {
         const item = document.createElement("div");
         item.className = "suggestion-item";
+        item.tabIndex = 0;
         const country = stock.CountryShort ? ` -${stock.CountryShort}` : '';
         item.innerText = `${stock.Name} (${stock.Symbol})${country}`;
         item.onclick = () => {
@@ -306,7 +309,39 @@ async function searchTicker() {
             evaluateStock(stock.Symbol);
             suggestionsDiv.innerHTML = '';
         };
+        item.addEventListener('keydown', (e) => {
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                (item.nextElementSibling || suggestionsDiv.firstElementChild).focus();
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                if (item.previousElementSibling) {
+                    item.previousElementSibling.focus();
+                } else {
+                    searchInput.focus();
+                }
+            } else if (e.key === 'Enter') {
+                e.preventDefault();
+                item.click();
+            }
+        });
         suggestionsDiv.appendChild(item);
+    });
+}
+
+const searchInputField = document.getElementById('search');
+if (searchInputField) {
+    searchInputField.addEventListener('keydown', (e) => {
+        const suggestionsDiv = document.getElementById('suggestions');
+        if (!suggestionsDiv) return;
+        const items = suggestionsDiv.querySelectorAll('.suggestion-item');
+        if (e.key === 'ArrowDown' && items.length) {
+            e.preventDefault();
+            items[0].focus();
+        } else if (e.key === 'ArrowUp' && items.length) {
+            e.preventDefault();
+            items[items.length - 1].focus();
+        }
     });
 }
 

--- a/static/script.js
+++ b/static/script.js
@@ -635,12 +635,16 @@ window.showResults = function () {
     const exportBtn = document.getElementById('export-btn');
     const quoteContainer = document.getElementById('quote-container');
     const pageBackground = document.getElementById("page-background");
+    const mobileActions = document.querySelector('.mobile-action-buttons');
     if (initialView) {
         initialView.classList.remove('expanded');
         initialView.classList.add('shrunk');
         if (exportBtn) exportBtn.style.display = 'inline-flex';
         if (quoteContainer) quoteContainer.style.display = 'none';
         if (pageBackground) pageBackground.style.animation = 'none';
+        if (mobileActions && window.matchMedia('(max-width: 600px)').matches) {
+            mobileActions.style.display = 'flex';
+        }
     }
     if (resultsView) resultsView.style.display = 'block';
 };

--- a/static/styles.css
+++ b/static/styles.css
@@ -878,7 +878,6 @@ body.about-page #page-background {
     transform: none;
   }
   .mobile-action-buttons {
-    display: flex;
     gap: 10px;
     margin-left: auto;
   }

--- a/static/styles.css
+++ b/static/styles.css
@@ -873,7 +873,7 @@ body.about-page #page-background {
   }
   #import-btn,
   #export-btn {
-    display: none;
+    display: none !important;
   }
   #watchlist-table td.col-score,
   #watchlist-table td.ai-cell {

--- a/static/styles.css
+++ b/static/styles.css
@@ -172,6 +172,11 @@ span {
   transform: translateY(-5px);
 }
 
+/* Hidden by default; mobile-only action buttons for run all and score settings */
+.mobile-action-buttons {
+  display: none;
+}
+
 /* ==== Watchlist Table ==== */
 #watchlist {
   position: relative;
@@ -865,11 +870,17 @@ body.about-page #page-background {
     padding: 0 10px;
   }
   .search-container {
-    flex-direction: column;
+    flex-direction: row;
+    align-items: center;
     min-width: 0;
   }
   .search-container button {
     transform: none;
+  }
+  .mobile-action-buttons {
+    display: flex;
+    gap: 10px;
+    margin-left: auto;
   }
   #import-btn,
   #export-btn {

--- a/static/styles.css
+++ b/static/styles.css
@@ -890,8 +890,16 @@ body.about-page #page-background {
     display: flex;
     justify-content: center;
   }
+  #watchlist-table td.col-score {
+    flex-direction: column;
+    align-items: center;
+  }
+  #watchlist-table td.col-score::before {
+    text-align: center;
+    width: 100%;
+  }
   #watchlist-table td.ai-cell {
-    margin-top: 8px;
+    margin-top: 16px;
   }
   #watchlist-table th,
   #watchlist-table td {

--- a/static/styles.css
+++ b/static/styles.css
@@ -163,6 +163,10 @@ span {
 .suggestion-item:hover {
   background-color: #3a3a3a;
 }
+.suggestion-item:focus {
+  background-color: #3a3a3a;
+  outline: none;
+}
 
 .search-container button {
   transform: translateY(-5px);
@@ -798,7 +802,7 @@ body.about-page #page-background {
 
 /* ==== Mobile Layout Adjustments ==== */
 @media (max-width: 600px) {
-  nav { position: fixed; bottom: 0; left: 0; width: 100%; background: #1e1e1e; border-top: 1px solid #444; justify-content: space-around; padding: 10px 0; gap: 0; }
+  nav { position: fixed; bottom: 0; left: 0; width: 100%; background: #1e1e1e; border-top: 1px solid #444; justify-content: space-around; padding: 10px 0; gap: 0; opacity: 1; }
   body { padding-bottom: 60px; }
   nav a { display: flex; flex-direction: column; align-items: center; font-size: 12px; }
   #watchlist-table thead { display: none; }
@@ -866,6 +870,18 @@ body.about-page #page-background {
   }
   .search-container button {
     transform: none;
+  }
+  #import-btn,
+  #export-btn {
+    display: none;
+  }
+  #watchlist-table td.col-score,
+  #watchlist-table td.ai-cell {
+    display: flex;
+    justify-content: center;
+  }
+  #watchlist-table td.ai-cell {
+    margin-top: 8px;
   }
   #watchlist-table th,
   #watchlist-table td {

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,7 +38,7 @@
             <div class="search-container">
                 <div class="input-wrapper">
                     <!-- Ticker search box -->
-                    <input id="search" type="text" style="width: 210px" oninput="searchTicker()"
+                    <input id="search" type="text" oninput="searchTicker()"
                         placeholder="Search by name or symbol" autocomplete="off" />
 
                     <!-- Dropdown for search suggestions -->
@@ -53,7 +53,7 @@
                     onchange="importFromExcel(event)" />
 
                 <!-- Import button (opens file picker) -->
-                <button onclick="document.getElementById('excel-import').click()" style="margin-top: 10px;">
+                <button id="import-btn" onclick="document.getElementById('excel-import').click()" style="margin-top: 10px;">
                     <svg viewBox="0 0 24 24" width="12" height="12">
                         <path d="M8 11h-6v10h20v-10h-6v-2h8v14h-24v-14h8v2zm-1-4l5-6 5 6h-4v11h-2v-11h-4z" />
                     </svg>

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,6 +67,12 @@
                     </svg>
                     Export
                 </button>
+
+                <!-- Mobile action buttons: run all and score settings -->
+                <div class="mobile-action-buttons">
+                    <button id="mobile-run-all" onclick="runAllAI()">Run All</button>
+                    <button id="mobile-score-btn" onclick="openWeightModal()" title="Adjust scoring weights">⚙</button>
+                </div>
             </div>
 
             <!-- Dynamic quote preview (e.g., after search) -->


### PR DESCRIPTION
## Summary
- Sync ticker suggestions dropdown width with the search field
- Tidy mobile layout: hide import/export buttons, center score and AI play button, and make bottom nav fully opaque
- Allow keyboard navigation of ticker suggestions with arrow keys and Enter, and highlight focused suggestions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688fc8e8e954832f900483a2f70a3dfd