### PR TITLE
Separate background gradient from main layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -8,8 +8,6 @@ body {
   overflow-x: hidden;
   box-sizing: border-box;
   font-family: Arial, sans-serif;
-  position: relative;
-  z-index: 1;
 }
 
 /* ==== Navigation Bar ==== */
@@ -63,6 +61,7 @@ span {
   width: 100vw;
   height: 100vh;
   z-index: -1;
+  pointer-events: none;
   background: linear-gradient(135deg, #1e1e1e, #646464, #1e1e1e);
   background-size: 300% 300%;
   animation: moveDiagonalGradient 40s ease infinite;

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,9 +13,10 @@
 </head>
 
 <body>
-    <div id="page-background">
-        <!-- ==== Main Navigation ==== -->
-        <nav>
+    <div id="page-background"></div>
+
+    <!-- ==== Main Navigation ==== -->
+    <nav>
             <a href="/">
                 <svg class="nav-icon" viewBox="0 0 24 24" width="24" height="24"><path d="M12 3l10 9h-3v9h-6v-5H11v5H5v-9H2z"/></svg>
                 <span>Home</span>


### PR DESCRIPTION
## Summary
- Move navigation, stock views, modals, and toast outside of the background container so the gradient div is empty.
- Rework styles so `#page-background` is a fixed, pointer-free gradient layer and other content stays in normal stacking order.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fd8b8392c832fbcedb7fc40c0fe5f