### PR TITLE
Refine mobile tab bar visibility and tap targets

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -12,10 +12,7 @@ body {
 
 /* ==== Navigation Bar ==== */
 nav {
-  display: flex;
-  justify-content: center;
-  gap: 30px;
-  padding: 20px 0;
+  display: none;
 }
 
 nav a {
@@ -806,9 +803,27 @@ body.about-page #page-background {
 
 /* ==== Mobile Layout Adjustments ==== */
 @media (max-width: 600px) {
-  nav { position: fixed; bottom: 0; left: 0; width: 100%; background: #1e1e1e; border-top: 1px solid #444; justify-content: space-around; padding: 10px 0; gap: 0; opacity: 1; }
+  nav {
+    display: flex;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background-color: #1e1e1e;
+    border-top: 1px solid #444;
+    justify-content: space-around;
+    padding: 12px 0;
+    gap: 0;
+  }
   body { padding-bottom: 60px; }
-  nav a { display: flex; flex-direction: column; align-items: center; font-size: 12px; }
+  nav a {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-size: 12px;
+    padding: 10px 20px;
+    flex: 1;
+  }
   #watchlist-table thead { display: none; }
   #watchlist-table tr {
     display: grid;
@@ -877,8 +892,12 @@ body.about-page #page-background {
     transform: none;
   }
   .mobile-action-buttons {
+    display: flex;
     gap: 10px;
     margin-left: auto;
+  }
+  .mobile-action-buttons button {
+    padding: 10px 14px;
   }
   #import-btn,
   #export-btn {

--- a/static/styles.css
+++ b/static/styles.css
@@ -892,7 +892,7 @@ body.about-page #page-background {
     transform: none;
   }
   .mobile-action-buttons {
-    display: flex;
+    /* hidden by default; revealed via showResults() */
     gap: 10px;
     margin-left: auto;
   }

--- a/templates/about.html
+++ b/templates/about.html
@@ -28,10 +28,10 @@
 
 <body class="about-page">
     <!-- ==== Full-Page Background (matches app style) ==== -->
-    <div id="page-background">
+    <div id="page-background"></div>
 
-        <!-- ==== Main Navigation ==== -->
-         <nav>
+    <!-- ==== Main Navigation ==== -->
+    <nav>
             <a href="/">
                 <svg class="nav-icon" viewBox="0 0 24 24" width="24" height="24"><path d="M12 3l10 9h-3v9h-6v-5H11v5H5v-9H2z"/></svg>
                 <span>Home</span>
@@ -44,9 +44,9 @@
                 <svg class="nav-icon" viewBox="0 0 24 24" width="24" height="24"><path d="M12 2a10 10 0 100 20 10 10 0 000-20zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg>
                 <span>About</span>
             </a>
-        </nav>
-        <!-- ==== About Section Container ==== -->
-        <div class="about-container">
+    </nav>
+    <!-- ==== About Section Container ==== -->
+    <div class="about-container">
 
             <!-- ==== Page Title ==== -->
             <h1>About Me</h1>
@@ -80,10 +80,8 @@
                 </iframe>
             </div>
 
-        </div>
-        <!-- ==== End About Container ==== -->
-
     </div>
-    <!-- ==== End Page Background ==== -->
+    <!-- ==== End About Container ==== -->
+
 </body>
 </html>

--- a/templates/tools.html
+++ b/templates/tools.html
@@ -25,10 +25,10 @@
 
 <body>
     <!-- ==== Background Container ==== -->
-    <div id="page-background">
+    <div id="page-background"></div>
 
-        <!-- ==== Main Navigation ==== -->
-        <nav>
+    <!-- ==== Main Navigation ==== -->
+    <nav>
             <a href="/">
                 <svg class="nav-icon" viewBox="0 0 24 24" width="24" height="24"><path d="M12 3l10 9h-3v9h-6v-5H11v5H5v-9H2z"/></svg>
                 <span>Home</span>
@@ -41,10 +41,10 @@
                 <svg class="nav-icon" viewBox="0 0 24 24" width="24" height="24"><path d="M12 2a10 10 0 100 20 10 10 0 000-20zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg>
                 <span>About</span>
             </a>
-        </nav>
+    </nav>
 
-        <!-- ==== Main Tools Container ==== -->
-        <div id="tools-container">
+    <!-- ==== Main Tools Container ==== -->
+    <div id="tools-container">
 
             <!-- ==== Brokers Column ==== -->
             <div class="tools-column">
@@ -77,10 +77,8 @@
                 <br>Basically social media but for stock traders. If there's a trader you like to follow, most likely they'll have an account here 
             </div>
 
-        </div>
-        <!-- ==== End Tools Container ==== -->
     </div>
-    <!-- ==== End Page Background ==== -->
+    <!-- ==== End Tools Container ==== -->
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- Hide navigation tabs on desktop and show an opaque tab bar on mobile
- Increase tap areas for mobile nav links and action buttons
- Enable mobile nav tabs and scrolling on Tools and About pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689128fda00c832f93da4b4fe237ba20