### PR TITLE
fix: prevent mobile page scroll and input zoom

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -818,8 +818,30 @@ body.about-page #page-background {
     backdrop-filter: blur(5px); /* optional: make semi-transparency look clean */
   }
 
+  html,
   body {
-    padding-bottom: calc(60px + env(safe-area-inset-bottom)); /* make room for nav */
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  body {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+
+  #initial-view,
+  #results-view {
+    height: calc(100vh - 60px - env(safe-area-inset-bottom));
+    margin-top: 0;
+  }
+
+  #initial-view {
+    overflow-y: auto;
+  }
+
+  #results-view {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
   }
 
   nav a {
@@ -830,6 +852,23 @@ body.about-page #page-background {
     padding: 10px 20px;
     flex: 1;
     color: white; /* ensure visible on dark nav background */
+  }
+
+  input[type="text"],
+  input[type="number"],
+  #search {
+    font-size: 16px;
+  }
+
+  #watchlist {
+    flex: 1 1 auto;
+    height: auto;
+    max-height: none;
+    overflow-y: auto;
+  }
+
+  #result {
+    flex-shrink: 0;
   }
 
   #watchlist-table thead {

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 <html>
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <!-- SheetJS for Excel export/import -->
     <script src="https://cdn.sheetjs.com/xlsx-latest/package/dist/xlsx.full.min.js"></script>
     <title>Stock Watchlist</title>


### PR DESCRIPTION
## Summary
- Ensure mobile layout does not scroll vertically and keeps navigation pinned to bottom
- Increase mobile input font size and disable user scaling to avoid zoom on focus
- Restructure results view so stock table and messages stay above fixed bottom nav

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689136881a40832fa5c848a61ec7dc1e