### PR TITLE
Improve iOS mobile layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -8,7 +8,6 @@ body {
   overflow-x: hidden;
   box-sizing: border-box;
   font-family: Arial, sans-serif;
-  background-color: #1e1e1e;
 }
 
 /* ==== Navigation Bar ==== */

--- a/static/styles.css
+++ b/static/styles.css
@@ -8,7 +8,7 @@ body {
   overflow-x: hidden;
   box-sizing: border-box;
   font-family: Arial, sans-serif;
-  background-color: #000;
+  background-color: #1e1e1e;
 }
 
 /* ==== Navigation Bar ==== */
@@ -60,9 +60,9 @@ span {
   height: 100vh;
   z-index: -1;
   pointer-events: none;
-  background: linear-gradient(135deg, #000, #fff);
-  background-size: 400% 400%;
-  animation: moveDiagonalGradient 30s ease infinite;
+  background: linear-gradient(135deg, #1e1e1e, #646464, #1e1e1e);
+  background-size: 300% 300%;
+  animation: moveDiagonalGradient 40s ease infinite;
 }
 
 @keyframes moveDiagonalGradient {

--- a/static/styles.css
+++ b/static/styles.css
@@ -8,6 +8,7 @@ body {
   overflow-x: hidden;
   box-sizing: border-box;
   font-family: Arial, sans-serif;
+  background-color: #1e1e1e;
 }
 
 /* ==== Navigation Bar ==== */
@@ -378,7 +379,7 @@ input[type="number"],
   color: #1e1e1e;
   padding: 6px 14px;
   font-weight: 600;
-  font-size: 14px;
+  font-size: 16px;
   border-radius: 6px;
   outline: none;
   transition: all 0.3s ease;
@@ -813,9 +814,13 @@ body.about-page #page-background {
     border-top: 1px solid #444;
     justify-content: space-around;
     padding: 12px 0;
+    padding-bottom: calc(12px + env(safe-area-inset-bottom));
     gap: 0;
   }
-  body { padding-bottom: 60px; }
+  body {
+    padding-bottom: calc(60px + env(safe-area-inset-bottom));
+    padding-top: env(safe-area-inset-top);
+  }
   nav a {
     display: flex;
     flex-direction: column;

--- a/static/styles.css
+++ b/static/styles.css
@@ -8,7 +8,7 @@ body {
   overflow-x: hidden;
   box-sizing: border-box;
   font-family: Arial, sans-serif;
-  background-color: #1e1e1e;
+  background-color: #000;
 }
 
 /* ==== Navigation Bar ==== */
@@ -60,9 +60,9 @@ span {
   height: 100vh;
   z-index: -1;
   pointer-events: none;
-  background: linear-gradient(135deg, #1e1e1e, #646464, #1e1e1e);
-  background-size: 300% 300%;
-  animation: moveDiagonalGradient 40s ease infinite;
+  background: linear-gradient(135deg, #000, #fff);
+  background-size: 400% 400%;
+  animation: moveDiagonalGradient 30s ease infinite;
 }
 
 @keyframes moveDiagonalGradient {

--- a/templates/about.html
+++ b/templates/about.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no, viewport-fit=cover">
     <title>About Me</title>
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='icons/website-icon.png') }}">
     <!-- ==== Inline Styles for Links and Nav (can be moved to main CSS) ==== -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 <html>
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no, viewport-fit=cover">
     <!-- SheetJS for Excel export/import -->
     <script src="https://cdn.sheetjs.com/xlsx-latest/package/dist/xlsx.full.min.js"></script>
     <title>Stock Watchlist</title>

--- a/templates/tools.html
+++ b/templates/tools.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no, viewport-fit=cover">
     <title>Other Tools</title>
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='icons/website-icon.png') }}">
     <!-- ==== Inline Styles for Links and Nav (consider moving to styles.css) ==== -->


### PR DESCRIPTION
## Summary
- Ensure iOS devices respect safe areas and full‑screen view by adding `viewport-fit=cover`, disabling zoom, and locking scale across all templates.
- Increase input font size to stop Safari auto‑zoom and style body background to prevent white bars.
- Add safe‑area padding to body and bottom navigation so tabs no longer overlap list cards on mobile.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68913e228030832fa0437f12c4732349