### PR TITLE
Fix mobile nav overlay and restore desktop navigation

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -89,12 +89,16 @@ span {
 
 /* Centered splash layout for initial screen */
 .centered-view.expanded {
-  display: flex;
   flex-direction: column;
   justify-content: center;  /* centers vertically */
   align-items: center;      /* centers horizontally */
   flex: 1;
   text-align: center;
+}
+@media (min-width: 1000px) {
+  .centered-view.expanded{
+    display: flex;
+  }
 }
 
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -8,17 +8,25 @@ body {
   overflow-x: hidden;
   box-sizing: border-box;
   font-family: Arial, sans-serif;
+  display: flex;
+  flex-direction: column;
 }
 
 /* ==== Navigation Bar ==== */
 nav {
-  display: none;
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  padding: 12px 0;
+  background-color: #1e1e1e;
 }
 
 nav a {
   color: white;
   text-decoration: none;
   font-weight: bold;
+  display: flex;
+  align-items: center;
 }
 
 nav a:hover {
@@ -81,16 +89,12 @@ span {
 
 /* Centered splash layout for initial screen */
 .centered-view.expanded {
+  display: flex;
   flex-direction: column;
   justify-content: center;  /* centers vertically */
   align-items: center;      /* centers horizontally */
-  min-height: 100vh;        /* full viewport height */
+  flex: 1;
   text-align: center;
-}
-@media (min-width: 1000px) {
-  .centered-view.expanded{
-    display:flex
-  }
 }
 
 
@@ -978,9 +982,13 @@ body.about-page #page-background {
     height: 600px !important;
     min-height: 600px !important;
   }
+  .about-container {
+    padding-bottom: 100px;
+  }
   #tools-container {
     flex-direction: column;
     padding: 20px;
+    padding-bottom: 100px;
   }
   .tools-column + .tools-column {
     border-left: none;


### PR DESCRIPTION
## Summary
- Prevent bottom nav from obscuring content on mobile by adding bottom padding to the About and Tools containers
- Restore desktop navigation bar by displaying the nav container outside of mobile viewports
- Remove unwanted scrollbar on desktop by sizing the splash view to the remaining viewport height

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6892c45cadd4832f8483908acc14ea19