### PR TITLE
Add info modal for column descriptions

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -609,8 +609,24 @@ function exportToExcel() {
 function showModal(title, content) {
     const modal = document.getElementById("ai-modal");
     const container = document.getElementById("modal-content");
-    container.innerHTML = `<h3>${title}</h3><p>${content}</p>`;
+    container.innerHTML = `<h3>${title}</h3>${content}`;
     modal.style.display = "flex";
+}
+
+function openInfoModal() {
+    const headers = document.querySelectorAll('#watchlist-table thead th');
+    let list = '<ul class="info-list">';
+    headers.forEach(th => {
+        const desc = th.getAttribute('title');
+        const labelEl = th.querySelector('.th-label');
+        const rawLabel = labelEl ? labelEl.innerText : th.textContent;
+        const label = rawLabel.replace(/▲|▼/g, '').trim();
+        if (desc) {
+            list += `<li><strong>${label}</strong>: ${desc}</li>`;
+        }
+    });
+    list += '</ul>';
+    showModal('Column Information', list);
 }
 function closeModal() {
     document.getElementById("ai-modal").style.display = "none";

--- a/static/styles.css
+++ b/static/styles.css
@@ -210,6 +210,31 @@ span {
   box-sizing: border-box;
 }
 
+#watchlist-wrapper {
+  display: flex;
+  align-items: flex-start;
+}
+
+#watchlist-wrapper #info-btn {
+  margin-right: 8px;
+}
+
+#watchlist-wrapper #watchlist {
+  flex: 1;
+}
+
+#info-btn {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: 50%;
+  font-weight: bold;
+}
+
+.info-list {
+  list-style: disc;
+  padding-left: 20px;
+}
 
 #watchlist-table {
   width: 100%;

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,7 +81,9 @@
 
         <!-- Watchlist view  -->
         <div id="results-view" style="display: none;">
-            <div id="watchlist">
+            <div id="watchlist-wrapper">
+                <button id="info-btn" onclick="openInfoModal()" title="Column descriptions">ℹ</button>
+                <div id="watchlist">
                 <table id="watchlist-table">
                     <thead>
                         <tr>
@@ -234,6 +236,7 @@
                     <!-- Dynamic table body for stock rows -->
                     <tbody id="watchlist-body"></tbody>
                 </table>
+                </div>
             </div>
 
             <!-- Results or alerts after table -->


### PR DESCRIPTION
## Summary
- add info button to watchlist view that opens a modal describing each column
- gather descriptions from existing column tooltips and show in list
- style info button and list
- position info button inline with watchlist header for better mobile fit

## Testing
- `node --check static/script.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689bf2b5b218832f8ec3e14193dcc4aa