### PR TITLE
Fix About page image layout for responsive design

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -814,6 +814,73 @@ input[type="number"]:focus,
   dominant-baseline: middle;
   text-anchor: middle;
 }
+/* ==== About Page ==== */
+.about-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px;
+}
+
+body.about-page #page-background {
+  position: absolute;
+  width: 100vw;
+  min-height: 100vh;
+  height: auto;
+}
+
+.photo-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  gap: 32px;
+  /* space between photos */
+  margin-bottom: 32px;
+}
+
+#skiing-photo {
+  width: 480px;
+  height: 360px;
+}
+
+#profile-photo {
+  width: 385px;
+  height: 504px;
+}
+
+#fishing-photo {
+  width: 385px;
+  height: 504px;
+}
+
+.about-container p {
+  max-width: 600px;
+  text-align: center;
+  margin-bottom: 40px;
+}
+
+.resume-viewer {
+  width: 100vw;
+  min-width: 100vw;
+  margin: 0;
+  padding: 0;
+  max-width: none;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
+.resume-viewer iframe {
+  width: 50vw !important;
+  min-width: 50vw !important;
+  height: 1200px !important;
+  min-height: 1200px !important;
+  display: block;
+  border: none;
+  background: #fff;
+}
+
 /* ==== Mobile Layout Adjustments ==== */
 @media (max-width: 600px) {
 
@@ -1042,76 +1109,30 @@ input[type="number"]:focus,
 }
 
 
-/* ==== About Page ==== */
-.about-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 40px;
-}
+/* ==== About Page (Mobile) ==== */
+  .photo-row {
+    flex-direction: column;
+  }
 
-body.about-page #page-background {
-  position: absolute;
-  width: 100vw;
-  min-height: 100vh;
-  height: auto;
-}
+  #skiing-photo,
+  #profile-photo,
+  #fishing-photo {
+    width: 90vw;
+    height: auto;
+  }
 
-.photo-row {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  gap: 32px;
-  /* space between photos */
-  margin-bottom: 32px;
-}
+  .resume-viewer iframe {
+    width: 90vw !important;
+    min-width: 90vw !important;
+    height: 600px !important;
+    min-height: 600px !important;
+  }
 
-#skiing-photo {
-  width: 480px;
-  height: 360px;
-}
+  .about-container {
+    padding-bottom: 100px;
+  }
 
-#profile-photo {
-  width: 385px;
-  height: 504px;
-}
-
-#fishing-photo {
-  width: 385px;
-  height: 504px;
-}
-
-.about-container p {
-  max-width: 600px;
-  text-align: center;
-  margin-bottom: 40px;
-}
-
-.resume-viewer {
-  width: 100vw;
-  min-width: 100vw;
-  margin: 0;
-  padding: 0;
-  max-width: none;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-}
-
-.resume-viewer iframe {
-  width: 50vw !important;
-  min-width: 50vw !important;
-  height: 1200px !important;
-  min-height: 1200px !important;
-  display: block;
-  border: none;
-  background: #fff;
-}
-
-
-
-/* ==== Tools Page ==== */
+  /* ==== Tools Page ==== */
 #tools-container {
   display: flex;
   justify-content: center;
@@ -1132,27 +1153,6 @@ body.about-page #page-background {
   margin-bottom: 20px;
 }
 
-.photo-row {
-  flex-direction: column;
-}
-
-#skiing-photo,
-#profile-photo,
-#fishing-photo {
-  width: 90vw;
-  height: auto;
-}
-
-.resume-viewer iframe {
-  width: 90vw !important;
-  min-width: 90vw !important;
-  height: 600px !important;
-  min-height: 600px !important;
-}
-
-.about-container {
-  padding-bottom: 100px;
-}
 
 #tools-container {
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add desktop layout for About page images
- make About page images stack vertically on small screens

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c009d4538832fadb75f5d09efea79